### PR TITLE
Prevent Error From Being Thrown

### DIFF
--- a/lib/capistrano/tasks/linked_files.rake
+++ b/lib/capistrano/tasks/linked_files.rake
@@ -16,7 +16,7 @@ namespace :linked_files do
 
     task :files do
       on roles :web do
-        fetch(:linked_files).each do |file|
+        fetch(:linked_files, []).each do |file|
           upload! file, "#{shared_path}/#{file}"
         end
       end
@@ -24,7 +24,7 @@ namespace :linked_files do
 
     task :dirs do
       on roles :web do
-        fetch(:linked_dirs).each do |dir|
+        fetch(:linked_dirs, []).each do |dir|
           upload! dir, "#{shared_path}/", recursive: true
         end
       end


### PR DESCRIPTION
Right now, if you invoke linked_files:upload and either :linked_dirs or :linked_files aren't set, it will throw an error. This patch just adds a default to the fetch call, so that they will simply be skipped.
